### PR TITLE
Fix: 참조 무결성 제약으로 인해 member 제거 안되는 버그 수정

### DIFF
--- a/src/main/java/com/hangoutwithus/hangoutwithus/entity/ChatRoom.java
+++ b/src/main/java/com/hangoutwithus/hangoutwithus/entity/ChatRoom.java
@@ -2,10 +2,8 @@ package com.hangoutwithus.hangoutwithus.entity;
 
 import lombok.Getter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -14,5 +12,8 @@ public class ChatRoom extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatRoomInfo> chatRoomInfos;
 
 }

--- a/src/main/java/com/hangoutwithus/hangoutwithus/entity/Member.java
+++ b/src/main/java/com/hangoutwithus/hangoutwithus/entity/Member.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,15 +34,24 @@ public class Member extends BaseEntity {
     @Column
     private Boolean isCompletedSignup;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private Post post;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private Geolocation geolocation;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatRoomInfo> chatRooms;
+
+    @OneToMany(mappedBy = "likeTo", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<MemberLike> likeToList;
+
+    @OneToMany(mappedBy = "likeFrom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<MemberLike> likeFromList;
+
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
 
 
     public void addPost(Post post) {


### PR DESCRIPTION
@OneToMany 의 CascadeType.REMOVE 옵션으로 해결

close #1 